### PR TITLE
Hermes relayer integration

### DIFF
--- a/network/hermes/README.md
+++ b/network/hermes/README.md
@@ -1,0 +1,44 @@
+# Hermes Relayer
+
+[Hermes](https://hermes.informal.systems/) is a Rust implementation of a relayer for the [Inter-Blockchain Communication (IBC)](https://ibcprotocol.org/) protocol.
+
+> The Inter-Blockchain Communication protocol is an end-to-end, connection-oriented, stateful protocol for reliable, ordered, and authenticated communication between modules on separate distributed ledgers.
+
+## Getting started
+
+- Install [Rust](https://www.rust-lang.org/tools/install)
+- Install [Hermes](https://hermes.informal.systems/installation.html)
+
+The following directory contains a basic executable script which handles creation of clients, connections and channels in order to facilitate packet relaying between distributed ledgers using the IBC protocol.
+This serves as a basis for demonstration of interchain accounts e2e functionality validation.
+
+## Usage
+
+- Before attempting to create clients, connections and channels, the private keys for existing chains must be restored. Please note - currently the relayer does NOT support a keyring store to securely store the private key file. The key file will be stored on the local file system in the user `$HOME` folder under `$HOME/.hermes`
+```
+hermes -c config.toml keys restore $CHAIN_ID -m $MNEMONIC
+hermes -c config.toml keys restore $CHAIN_ID -m $MNEMONIC
+```
+
+- Execute the script
+```
+./hermes.sh
+```
+
+- Useful commands
+```
+# Query client state
+hermes query client state $CHAIN_ID 07-tendermint-0
+
+# Update client state by sending an update-client transaction
+hermes tx raw update-client $CHAIN_ID 07-tendermint-0
+
+# Query a connection end
+hermes query connection end $CHAIN_ID connection-0
+
+# Query channel ends
+hermes query channel end $CHAIN_ID transfer channel-0
+hermes query channel end $CHAIN_ID ibcaccount channel-1
+```
+
+Please refer to the [Hermes documentation](https://hermes.informal.systems/) for more information regarding various commands.

--- a/network/hermes/config.toml
+++ b/network/hermes/config.toml
@@ -1,0 +1,41 @@
+[global]
+strategy = 'naive'
+log_level = 'info'
+
+[[chains]]
+id = 'test-1'
+rpc_addr = 'http://127.0.0.1:16657'
+grpc_addr = 'http://127.0.0.1:8090'
+websocket_addr = 'ws://127.0.0.1:16657/websocket'
+rpc_timeout = '10s'
+account_prefix = 'cosmos'
+key_name = 'testkey'
+store_prefix = 'ibc'
+gas = 3000000
+fee_denom = 'stake'
+fee_amount = 10
+clock_drift = '5s'
+trusting_period = '14days'
+
+[chains.trust_threshold]
+numerator = '1'
+denominator = '3'
+
+[[chains]]
+id = 'test-2'
+rpc_addr = 'http://127.0.0.1:26657'
+grpc_addr = 'http://127.0.0.1:9090'
+websocket_addr = 'ws://127.0.0.1:26657/websocket'
+rpc_timeout = '10s'
+account_prefix = 'cosmos'
+key_name = 'testkey'
+store_prefix = 'ibc'
+gas = 3000000
+fee_denom = 'stake'
+fee_amount = 1000
+clock_drift = '5s'
+trusting_period = '14days'
+
+[chains.trust_threshold]
+numerator = '1'
+denominator = '3'

--- a/network/hermes/hermes.sh
+++ b/network/hermes/hermes.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+### Configure clients
+echo "Configuring clients..."
+hermes -c config.toml tx raw create-client test-1 test-2
+hermes -c config.toml tx raw create-client test-2 test-1
+
+### Connection Handshake
+echo "Initiating connection handshake..."
+# conn-init
+hermes -c config.toml tx raw conn-init test-1 test-2 07-tendermint-0 07-tendermint-0
+# conn-try
+hermes -c config.toml tx raw conn-try test-2 test-1 07-tendermint-0 07-tendermint-0 -s connection-0
+# conn-ack
+hermes -c config.toml tx raw conn-ack test-1 test-2 07-tendermint-0 07-tendermint-0 -d connection-0 -s connection-0
+# conn-confirm
+hermes -c config.toml tx raw conn-confirm test-2 test-1 07-tendermint-0 07-tendermint-0 -d connection-0 -s connection-0
+
+### Create an ics-20 transfer channel
+echo "Creating ics-20 transfer channel..."
+# chan-open-init
+hermes -c config.toml tx raw chan-open-init test-1 test-2 connection-0 transfer transfer -o UNORDERED
+# chan-open-try
+hermes -c config.toml tx raw chan-open-try test-2 test-1 connection-0 transfer transfer -s channel-0
+# chan-open-ack
+hermes -c config.toml tx raw chan-open-ack test-1 test-2 connection-0 transfer transfer -d channel-0 -s channel-0
+# chan-open-confirm
+hermes -c config.toml tx raw chan-open-confirm test-2 test-1 connection-0 transfer transfer -d channel-0 -s channel-0
+
+### Create an ics-27 ibcaccount channel
+echo "Creating ics-27 ibcaccount channel..."
+# chan-open-init
+hermes -c config.toml tx raw chan-open-init test-1 test-2 connection-0 ibcaccount ibcaccount -o ORDERED
+# chan-open-try
+hermes -c config.toml tx raw chan-open-try test-2 test-1 connection-0 ibcaccount ibcaccount -s channel-1
+# chan-open-ack
+hermes -c config.toml tx raw chan-open-ack test-1 test-2 connection-0 ibcaccount ibcaccount -d channel-1 -s channel-1
+# chan-open-confirm
+hermes -c config.toml tx raw chan-open-confirm test-2 test-1 connection-0 ibcaccount ibcaccount -d channel-1 -s channel-1
+
+# Start the hermes relayer in multi-paths mode
+echo "Starting hermes relayer..."
+hermes -c config.toml start-multi

--- a/network/init.sh
+++ b/network/init.sh
@@ -79,8 +79,8 @@ echo "Starting $CHAINID_1 in $CHAIN_DIR..."
 echo "Creating log file at $CHAIN_DIR/$CHAINID_1.log"
 $BINARY start --home $CHAIN_DIR/$CHAINID_1 --pruning=nothing --grpc.address="0.0.0.0:$GRPCPORT_1" > $CHAIN_DIR/$CHAINID_1.log 2>&1 &
 
-echo "Starting $CHAINID_1 in $CHAIN_DIR..."
-echo "Creating log file at $CHAIN_DIR/$CHAINID_1.log"
+echo "Starting $CHAINID_2 in $CHAIN_DIR..."
+echo "Creating log file at $CHAIN_DIR/$CHAINID_2.log"
 $BINARY start --home $CHAIN_DIR/$CHAINID_2 --pruning=nothing --grpc.address="0.0.0.0:$GRPCPORT_2" > $CHAIN_DIR/$CHAINID_2.log 2>&1 &
 
 

--- a/x/ibc-account/keeper/relay.go
+++ b/x/ibc-account/keeper/relay.go
@@ -42,7 +42,7 @@ func (k Keeper) TryRegisterIBCAccount(ctx sdk.Context, sourcePort, sourceChannel
 
 	// timeoutTimestamp is set to be a max number here so that we never recieve a timeout
 	// ics-27-1 uses ordered channels which can close upon recieving a timeout, which is an undesired effect
-	const timeoutTimestamp = ^uint64(0)
+	const timeoutTimestamp = ^uint64(0) >> 1 // Shift the unsigned bit to satisfy hermes relayer timestamp conversion
 
 	packet := channeltypes.NewPacket(
 		packetData.GetBytes(),
@@ -128,7 +128,7 @@ func (k Keeper) createOutgoingPacket(
 
 	// timeoutTimestamp is set to be a max number here so that we never recieve a timeout
 	// ics-27-1 uses ordered channels which can close upon recieving a timeout, which is an undesired effect
-	const timeoutTimestamp = ^uint64(0)
+	const timeoutTimestamp = ^uint64(0) >> 1 // Shift the unsigned bit to satisfy hermes relayer timestamp conversion
 
 	packet := channeltypes.NewPacket(
 		packetData.GetBytes(),


### PR DESCRIPTION
The following PR adds a basic Hermes relayer configuration and associated initialisation script for creation of client, connection and channel entities used by the IBC protocol to handle packet relaying between IBC enabled chains.

Please see network/hermes/README.md for prerequisite info.

This PR includes a minor change to `timeoutTimestamp` whereby the unsigned bit is shifted to the right, allowing for the Hermes relayer to successfully relay packets and avoid overflow when Hermes performs timestamp conversion.

See: https://github.com/informalsystems/ibc-rs/blob/master/modules/src/timestamp.rs#L46

```
WARN ibc_relayer::event::rpc: error while building event send_packet.packet_data
WARN ibc_relayer::event::rpc: error while building event Error converting from u64 to i64: out of range integral type conversion attempted
```