### PR TITLE
feat(hermes-relayer):updating makefile to use hermes relayer as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,17 +43,26 @@ proto-lint:
 init: kill-dev install 
 	@echo "Initializing both blockchains..."
 	./network/init.sh
+	./network/start.sh
 	@echo "Initializing relayer..." 
+	./network/hermes/hermes-restore-key.sh
+	./network/hermes/hermes.sh
+
+init-golang-rly: kill-dev install
+	@echo "Initializing both blockchains..."
+	./network/init.sh
+	./network/start.sh
+	@echo "Initializing relayer..."
 	./network/relayer/interchain-acc-config/rly.sh
 
 start: 
 	@echo "Starting up test network"
-	./network/init.sh
+	./network/start.sh
 
 start-rly:
-	./network/relayer/interchain-acc-config/rly.sh
+	./network/hermes/start.sh
 
 kill-dev:
 	@echo "Killing icad and removing previous data"
-	rm -rf ./data
+	-@rm -rf ./data
 	-@killall icad 2>/dev/null

--- a/network/hermes/hermes-restore-key.sh
+++ b/network/hermes/hermes-restore-key.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+### Sleep is needed otherwise the relayer crashes when trying to init
+sleep 1s
+### Restore Keys
+hermes -c ./network/hermes/config.toml keys restore test-2 -m "record gift you once hip style during joke field prize dust unique length more pencil transfer quit train device arrive energy sort steak upset"
+sleep 5s
+hermes -c ./network/hermes/config.toml keys restore test-1 -m "alley afraid soup fall idea toss can goose become valve initial strong forward bright dish figure check leopard decide warfare hub unusual join cart"
+sleep 5s
+

--- a/network/hermes/hermes.sh
+++ b/network/hermes/hermes.sh
@@ -1,44 +1,46 @@
 #!/bin/bash
 set -e
 
+CONFIG_DIR=./network/hermes/config.toml
+
 ### Configure clients
 echo "Configuring clients..."
-hermes -c config.toml tx raw create-client test-1 test-2
-hermes -c config.toml tx raw create-client test-2 test-1
+hermes -c $CONFIG_DIR tx raw create-client test-1 test-2
+hermes -c $CONFIG_DIR tx raw create-client test-2 test-1
 
 ### Connection Handshake
 echo "Initiating connection handshake..."
 # conn-init
-hermes -c config.toml tx raw conn-init test-1 test-2 07-tendermint-0 07-tendermint-0
+hermes -c $CONFIG_DIR tx raw conn-init test-1 test-2 07-tendermint-0 07-tendermint-0
 # conn-try
-hermes -c config.toml tx raw conn-try test-2 test-1 07-tendermint-0 07-tendermint-0 -s connection-0
+hermes -c $CONFIG_DIR tx raw conn-try test-2 test-1 07-tendermint-0 07-tendermint-0 -s connection-0
 # conn-ack
-hermes -c config.toml tx raw conn-ack test-1 test-2 07-tendermint-0 07-tendermint-0 -d connection-0 -s connection-0
+hermes -c $CONFIG_DIR tx raw conn-ack test-1 test-2 07-tendermint-0 07-tendermint-0 -d connection-0 -s connection-0
 # conn-confirm
-hermes -c config.toml tx raw conn-confirm test-2 test-1 07-tendermint-0 07-tendermint-0 -d connection-0 -s connection-0
-
-### Create an ics-20 transfer channel
-echo "Creating ics-20 transfer channel..."
-# chan-open-init
-hermes -c config.toml tx raw chan-open-init test-1 test-2 connection-0 transfer transfer -o UNORDERED
-# chan-open-try
-hermes -c config.toml tx raw chan-open-try test-2 test-1 connection-0 transfer transfer -s channel-0
-# chan-open-ack
-hermes -c config.toml tx raw chan-open-ack test-1 test-2 connection-0 transfer transfer -d channel-0 -s channel-0
-# chan-open-confirm
-hermes -c config.toml tx raw chan-open-confirm test-2 test-1 connection-0 transfer transfer -d channel-0 -s channel-0
+hermes -c $CONFIG_DIR tx raw conn-confirm test-2 test-1 07-tendermint-0 07-tendermint-0 -d connection-0 -s connection-0
 
 ### Create an ics-27 ibcaccount channel
 echo "Creating ics-27 ibcaccount channel..."
 # chan-open-init
-hermes -c config.toml tx raw chan-open-init test-1 test-2 connection-0 ibcaccount ibcaccount -o ORDERED
+hermes -c $CONFIG_DIR tx raw chan-open-init test-1 test-2 connection-0 ibcaccount ibcaccount -o ORDERED
 # chan-open-try
-hermes -c config.toml tx raw chan-open-try test-2 test-1 connection-0 ibcaccount ibcaccount -s channel-1
+hermes -c $CONFIG_DIR tx raw chan-open-try test-2 test-1 connection-0 ibcaccount ibcaccount -s channel-0
 # chan-open-ack
-hermes -c config.toml tx raw chan-open-ack test-1 test-2 connection-0 ibcaccount ibcaccount -d channel-1 -s channel-1
+hermes -c $CONFIG_DIR tx raw chan-open-ack test-1 test-2 connection-0 ibcaccount ibcaccount -d channel-0 -s channel-0
 # chan-open-confirm
-hermes -c config.toml tx raw chan-open-confirm test-2 test-1 connection-0 ibcaccount ibcaccount -d channel-1 -s channel-1
+hermes -c $CONFIG_DIR tx raw chan-open-confirm test-2 test-1 connection-0 ibcaccount ibcaccount -d channel-0 -s channel-0
+
+### Create an ics-20 transfer channel
+echo "Creating ics-20 transfer channel..."
+# chan-open-init
+hermes -c $CONFIG_DIR tx raw chan-open-init test-1 test-2 connection-0 transfer transfer -o UNORDERED
+# chan-open-try
+hermes -c $CONFIG_DIR tx raw chan-open-try test-2 test-1 connection-0 transfer transfer -s channel-1
+# chan-open-ack
+hermes -c $CONFIG_DIR tx raw chan-open-ack test-1 test-2 connection-0 transfer transfer -d channel-1 -s channel-1
+# chan-open-confirm
+hermes -c $CONFIG_DIR tx raw chan-open-confirm test-2 test-1 connection-0 transfer transfer -d channel-1 -s channel-1
 
 # Start the hermes relayer in multi-paths mode
 echo "Starting hermes relayer..."
-hermes -c config.toml start-multi
+hermes -c $CONFIG_DIR start-multi

--- a/network/hermes/hermes.sh
+++ b/network/hermes/hermes.sh
@@ -41,6 +41,3 @@ hermes -c $CONFIG_DIR tx raw chan-open-ack test-1 test-2 connection-0 transfer t
 # chan-open-confirm
 hermes -c $CONFIG_DIR tx raw chan-open-confirm test-2 test-1 connection-0 transfer transfer -d channel-1 -s channel-1
 
-# Start the hermes relayer in multi-paths mode
-echo "Starting hermes relayer..."
-hermes -c $CONFIG_DIR start-multi

--- a/network/hermes/start.sh
+++ b/network/hermes/start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Start the hermes relayer in multi-paths mode
+CONFIG_DIR=./network/hermes/config.toml
+
+echo "Starting hermes relayer..."
+hermes -c $CONFIG_DIR start-multi
+

--- a/network/init.sh
+++ b/network/init.sh
@@ -74,13 +74,3 @@ sed -i -e 's/index_all_keys = false/index_all_keys = true/g' $CHAIN_DIR/$CHAINID
 sed -i -e 's/enable = false/enable = true/g' $CHAIN_DIR/$CHAINID_2/config/app.toml
 sed -i -e 's/swagger = false/swagger = true/g' $CHAIN_DIR/$CHAINID_2/config/app.toml
 sed -i -e 's#"tcp://0.0.0.0:1317"#"tcp://0.0.0.0:'"$RESTPORT_2"'"#g' $CHAIN_DIR/$CHAINID_2/config/app.toml
-
-echo "Starting $CHAINID_1 in $CHAIN_DIR..."
-echo "Creating log file at $CHAIN_DIR/$CHAINID_1.log"
-$BINARY start --home $CHAIN_DIR/$CHAINID_1 --pruning=nothing --grpc.address="0.0.0.0:$GRPCPORT_1" > $CHAIN_DIR/$CHAINID_1.log 2>&1 &
-
-echo "Starting $CHAINID_2 in $CHAIN_DIR..."
-echo "Creating log file at $CHAIN_DIR/$CHAINID_2.log"
-$BINARY start --home $CHAIN_DIR/$CHAINID_2 --pruning=nothing --grpc.address="0.0.0.0:$GRPCPORT_2" > $CHAIN_DIR/$CHAINID_2.log 2>&1 &
-
-

--- a/network/start.sh
+++ b/network/start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+BINARY=icad
+CHAIN_DIR=./data
+CHAINID_1=test-1
+CHAINID_2=test-2
+GRPCPORT_1=8090
+GRPCPORT_2=9090
+
+echo "Starting $CHAINID_1 in $CHAIN_DIR..."
+echo "Creating log file at $CHAIN_DIR/$CHAINID_1.log"
+$BINARY start --home $CHAIN_DIR/$CHAINID_1 --pruning=nothing --grpc.address="0.0.0.0:$GRPCPORT_1" > $CHAIN_DIR/$CHAINID_1.log 2>&1 &
+
+echo "Starting $CHAINID_2 in $CHAIN_DIR..."
+echo "Creating log file at $CHAIN_DIR/$CHAINID_2.log"
+$BINARY start --home $CHAIN_DIR/$CHAINID_2 --pruning=nothing --grpc.address="0.0.0.0:$GRPCPORT_2" > $CHAIN_DIR/$CHAINID_2.log 2>&1 &
+


### PR DESCRIPTION
## Summary 

Updating the dev-environment to use the hermes relayer as a default. 

## How to test

`make init` 

This will start two chains locally and start the hermes relayer. It will configure a client, connection and create an ics20 & ics27 channel on the same connection. 

`make init-golang-rly` 

This is a legacy command for running the dev-environment with the golang relayer.