### PR TITLE
fix: removing tx encoder

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -325,11 +325,9 @@ func New(
 	)
 	transferModule := transfer.NewAppModule(app.TransferKeeper)
 
-	app.ibcAccountKeeper = ibcaccountkeeper.NewKeeper(keys[ibcaccounttypes.MemStoreKey], appCodec, keys[ibcaccounttypes.StoreKey],
-		map[string]ibcaccounttypes.TxEncoder{
-			// register the tx encoder for cosmos-sdk
-			"cosmos-sdk": ibcaccountkeeper.SerializeCosmosTx(appCodec, interfaceRegistry),
-		}, app.IBCKeeper.ChannelKeeper, &app.IBCKeeper.PortKeeper,
+	app.ibcAccountKeeper = ibcaccountkeeper.NewKeeper(
+		keys[ibcaccounttypes.MemStoreKey], appCodec, keys[ibcaccounttypes.StoreKey],
+		app.IBCKeeper.ChannelKeeper, &app.IBCKeeper.PortKeeper,
 		app.AccountKeeper, scopedIbcAccountKeeper, app.Router(), app,
 	)
 	ibcAccountModule := ibcaccount.NewAppModule(app.ibcAccountKeeper)

--- a/x/ibc-account/keeper/relay.go
+++ b/x/ibc-account/keeper/relay.go
@@ -33,7 +33,7 @@ func (k Keeper) TryRunTx(ctx sdk.Context, accountOwner sdk.AccAddress, data inte
 	destinationPort := sourceChannelEnd.GetCounterparty().GetPortID()
 	destinationChannel := sourceChannelEnd.GetCounterparty().GetChannelID()
 
-	return k.createOutgoingPacket(ctx, sourcePortId, activeChannelId, destinationPort, destinationChannel, "cosmos-sdk", data)
+	return k.createOutgoingPacket(ctx, sourcePortId, activeChannelId, destinationPort, destinationChannel, data)
 }
 
 func (k Keeper) createOutgoingPacket(
@@ -41,18 +41,12 @@ func (k Keeper) createOutgoingPacket(
 	sourcePort,
 	sourceChannel,
 	destinationPort,
-	destinationChannel,
-	typ string,
+	destinationChannel string,
 	data interface{},
 ) ([]byte, error) {
 
 	if data == nil {
 		return []byte{}, types.ErrInvalidOutgoingData
-	}
-
-	txEncoder, ok := k.GetTxEncoder(typ)
-	if !ok {
-		return []byte{}, types.ErrUnsupportedChain
 	}
 
 	var msgs []sdk.Msg
@@ -66,7 +60,7 @@ func (k Keeper) createOutgoingPacket(
 		return []byte{}, types.ErrInvalidOutgoingData
 	}
 
-	txBytes, err := txEncoder(msgs)
+	txBytes, err := k.SerializeCosmosTx(k.cdc, msgs)
 	if err != nil {
 		return []byte{}, sdkerrors.Wrap(err, "invalid packet data or codec")
 	}


### PR DESCRIPTION
Removing the tx encoder step. For now, we will only support cosmos SDK chains. We can add this functionality later if necessary.

Depends on: https://github.com/cosmos/interchain-accounts/pull/52