### PR TITLE
doc: Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,8 @@ This repo contains an ongoing refactor/update of https://github.com/chainapsis/c
 
 ```bash
 # Clone this repository and build
-git clone git@github.com:cosmos/interchain-account.git 
-cd ica
+git clone https://github.com/cosmos/interchain-accounts.git
+cd interchain-accounts
 make install 
 
 # Hermes Relayer


### PR DESCRIPTION
* Change git clone command to use https url instead of ssh (If user doesn't set ssh key for github account, it will fail.)
* Fix the path for cloned git repo