### PR TITLE
fix(hermes-relayer-dev-env): Add missing gas_price

### DIFF
--- a/network/hermes/config.toml
+++ b/network/hermes/config.toml
@@ -8,6 +8,7 @@ clock_drift = '5s'
 fee_amount = 10
 fee_denom = 'stake'
 gas = 3000000
+gas_price = { price = 0, denom = 'stake' }
 grpc_addr = 'http://127.0.0.1:8090'
 id = 'test-1'
 key_name = 'testkey'
@@ -27,6 +28,7 @@ clock_drift = '5s'
 fee_amount = 1000
 fee_denom = 'stake'
 gas = 3000000
+gas_price = { price = 0, denom = 'stake' }
 grpc_addr = 'http://127.0.0.1:9090'
 id = 'test-2'
 key_name = 'testkey'


### PR DESCRIPTION
<img width="729" alt="Screen Shot 2021-06-29 at 3 43 01 PM" src="https://user-images.githubusercontent.com/9255652/123751125-55e9c100-d8f2-11eb-8c67-8deb13068196.png">

`make init` fails due to missing `gas_price` in chains configuration.