### PR TITLE
test: adding tests for msg server register account

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -215,6 +215,7 @@ type App struct {
 	IBCKeeper           *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
 	ICAControllerKeeper icacontrollerkeeper.Keeper
 	ICAHostKeeper       icahostkeeper.Keeper
+	InterTxKeeper       intertxkeeper.Keeper
 	EvidenceKeeper      evidencekeeper.Keeper
 	TransferKeeper      ibctransferkeeper.Keeper
 	FeeGrantKeeper      feegrantkeeper.Keeper
@@ -224,8 +225,8 @@ type App struct {
 	ScopedTransferKeeper      capabilitykeeper.ScopedKeeper
 	ScopedICAControllerKeeper capabilitykeeper.ScopedKeeper
 	ScopedICAHostKeeper       capabilitykeeper.ScopedKeeper
+	ScopedInterTxKeeper       capabilitykeeper.ScopedKeeper
 
-	interTxKeeper intertxkeeper.Keeper
 	// this line is used by starport scaffolding # stargate/app/keeperDeclaration
 
 	// the module manager
@@ -364,9 +365,9 @@ func New(
 	)
 	icaModule := ica.NewAppModule(&app.ICAControllerKeeper, &app.ICAHostKeeper)
 
-	app.interTxKeeper = intertxkeeper.NewKeeper(appCodec, keys[intertxtypes.StoreKey], app.ICAControllerKeeper, scopedInterTxKeeper)
-	interTxModule := intertx.NewAppModule(appCodec, app.interTxKeeper)
-	interTxIBCModule := intertx.NewIBCModule(app.interTxKeeper)
+	app.InterTxKeeper = intertxkeeper.NewKeeper(appCodec, keys[intertxtypes.StoreKey], app.ICAControllerKeeper, scopedInterTxKeeper)
+	interTxModule := intertx.NewAppModule(appCodec, app.InterTxKeeper)
+	interTxIBCModule := intertx.NewIBCModule(app.InterTxKeeper)
 
 	icaControllerIBCModule := icacontroller.NewIBCModule(app.ICAControllerKeeper, interTxIBCModule)
 	icaHostIBCModule := icahost.NewIBCModule(app.ICAHostKeeper)
@@ -501,6 +502,7 @@ func New(
 	app.ScopedTransferKeeper = scopedTransferKeeper
 	app.ScopedICAControllerKeeper = scopedICAControllerKeeper
 	app.ScopedICAHostKeeper = scopedICAHostKeeper
+	app.ScopedInterTxKeeper = scopedInterTxKeeper
 
 	return app
 }

--- a/x/inter-tx/keeper/keeper_test.go
+++ b/x/inter-tx/keeper/keeper_test.go
@@ -5,12 +5,28 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	icatypes "github.com/cosmos/ibc-go/v2/modules/apps/27-interchain-accounts/types"
+	channeltypes "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types"
 	ibctesting "github.com/cosmos/ibc-go/v2/testing"
 
 	icaapp "github.com/cosmos/interchain-accounts/app"
+)
+
+var (
+	// TestAccAddress defines a resuable bech32 address for testing purposes
+	// TODO: update crypto.AddressHash() when sdk uses address.Module()
+	TestAccAddress = icatypes.GenerateAddress(sdk.AccAddress(crypto.AddressHash([]byte(icatypes.ModuleName))), TestPortID)
+	// TestOwnerAddress defines a reusable bech32 address for testing purposes
+	TestOwnerAddress = "cosmos17dtl0mjt3t77kpuhg2edqzjpszulwhgzuj9ljs"
+	// TestPortID defines a resuable port identifier for testing purposes
+	TestPortID, _ = icatypes.GeneratePortID(TestOwnerAddress, ibctesting.FirstConnectionID, ibctesting.FirstConnectionID)
+	// TestVersion defines a resuable interchainaccounts version string for testing purposes
+	TestVersion = icatypes.NewAppVersion(icatypes.VersionPrefix, TestAccAddress.String())
 )
 
 func init() {
@@ -35,6 +51,15 @@ type KeeperTestSuite struct {
 	chainB *ibctesting.TestChain
 }
 
+func (suite *KeeperTestSuite) GetICAApp(chain *ibctesting.TestChain) *icaapp.App {
+	app, ok := chain.App.(*icaapp.App)
+	if !ok {
+		panic("not ica app")
+	}
+
+	return app
+}
+
 // TestKeeperTestSuite runs all the tests within this package.
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
@@ -45,4 +70,16 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.coordinator = ibctesting.NewCoordinator(suite.T(), 2)
 	suite.chainA = suite.coordinator.GetChain(ibctesting.GetChainID(0))
 	suite.chainB = suite.coordinator.GetChain(ibctesting.GetChainID(1))
+}
+
+func NewICAPath(chainA, chainB *ibctesting.TestChain) *ibctesting.Path {
+	path := ibctesting.NewPath(chainA, chainB)
+	path.EndpointA.ChannelConfig.PortID = icatypes.PortID
+	path.EndpointB.ChannelConfig.PortID = icatypes.PortID
+	path.EndpointA.ChannelConfig.Order = channeltypes.ORDERED
+	path.EndpointB.ChannelConfig.Order = channeltypes.ORDERED
+	path.EndpointA.ChannelConfig.Version = icatypes.VersionPrefix
+	path.EndpointB.ChannelConfig.Version = TestVersion
+
+	return path
 }

--- a/x/inter-tx/keeper/msg_server.go
+++ b/x/inter-tx/keeper/msg_server.go
@@ -24,7 +24,7 @@ func (k msgServer) Register(
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	acc, err := sdk.AccAddressFromBech32(msg.Owner)
 	if err != nil {
-		return &types.MsgRegisterAccountResponse{}, err
+		return nil, err
 	}
 
 	err = k.RegisterInterchainAccount(
@@ -34,7 +34,7 @@ func (k msgServer) Register(
 		msg.CounterpartyConnectionId,
 	)
 	if err != nil {
-		return &types.MsgRegisterAccountResponse{}, err
+		return nil, err
 	}
 
 	return &types.MsgRegisterAccountResponse{}, nil

--- a/x/inter-tx/keeper/msg_server_test.go
+++ b/x/inter-tx/keeper/msg_server_test.go
@@ -1,0 +1,80 @@
+package keeper_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	icatypes "github.com/cosmos/ibc-go/v2/modules/apps/27-interchain-accounts/types"
+	ibctesting "github.com/cosmos/ibc-go/v2/testing"
+
+	"github.com/cosmos/interchain-accounts/x/inter-tx/keeper"
+	"github.com/cosmos/interchain-accounts/x/inter-tx/types"
+)
+
+func (suite *KeeperTestSuite) TestRegisterInterchainAccount() {
+	var (
+		owner string
+		path  *ibctesting.Path
+	)
+
+	testCases := []struct {
+		name     string
+		malleate func()
+		expPass  bool
+	}{
+		{
+			"success", func() {}, true,
+		},
+		{
+			"port is already bound",
+			func() {
+				suite.GetICAApp(suite.chainA).IBCKeeper.PortKeeper.BindPort(suite.chainA.GetContext(), TestPortID)
+			},
+			false,
+		},
+		{
+			"fails to generate port-id",
+			func() {
+				owner = ""
+			},
+			false,
+		},
+		{
+			"MsgChanOpenInit fails - channel is already active",
+			func() {
+				portID, err := icatypes.GeneratePortID(owner, path.EndpointA.ConnectionID, path.EndpointB.ConnectionID)
+				suite.Require().NoError(err)
+
+				suite.GetICAApp(suite.chainA).ICAControllerKeeper.SetActiveChannelID(suite.chainA.GetContext(), portID, path.EndpointA.ChannelID)
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+
+			owner = TestOwnerAddress // must be explicitly changed
+
+			path = NewICAPath(suite.chainA, suite.chainB)
+			suite.coordinator.SetupConnections(path)
+
+			tc.malleate() // malleate mutates test data
+
+			msgSrv := keeper.NewMsgServerImpl(suite.GetICAApp(suite.chainA).InterTxKeeper)
+			msg := types.NewMsgRegisterAccount(owner, path.EndpointA.ConnectionID, path.EndpointB.ConnectionID)
+
+			res, err := msgSrv.Register(sdk.WrapSDKContext(suite.chainA.GetContext()), msg)
+
+			if tc.expPass {
+				suite.Require().NoError(err)
+				suite.Require().NotNil(res)
+			} else {
+				suite.Require().Error(err)
+				suite.Require().Nil(res)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
- Adding tests for msg_server `Register`
- Adding helper functions for accessing ICAApp & path setup
- Updating App to correctly expose `interTxKeeper`