### PR TITLE
fix: resolve icad export panic (genesis)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -257,7 +257,7 @@ func New(
 	keys := sdk.NewKVStoreKeys(
 		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey,
 		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
-		govtypes.StoreKey, paramstypes.StoreKey, ibchost.StoreKey, upgradetypes.StoreKey,
+		govtypes.StoreKey, feegrant.StoreKey, paramstypes.StoreKey, ibchost.StoreKey, upgradetypes.StoreKey,
 		evidencetypes.StoreKey, ibctransfertypes.StoreKey, icacontrollertypes.StoreKey,
 		icahosttypes.StoreKey, capabilitytypes.StoreKey, intertxtypes.StoreKey,
 		// this line is used by starport scaffolding # stargate/app/storeKey


### PR DESCRIPTION
Fixes a bug whereby exporting genesis state to JSON with `icad export` would cause a panic due to a nil store key for `x/feegrant`. Identified while reproducing [ibc-go-673](https://github.com/cosmos/ibc-go/issues/673).

- adding feegrant store key to resolve panic on export genesis